### PR TITLE
Improve slot monitor backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # MonsterBox v1
+
+This repository contains a small example of a slot game monitoring service with a Flask backend and minimal frontend.
+
+## Structure
+
+- `slot-monitor-site/app.py` - Main Flask application
+- `slot-monitor-site/models.py` - SQLAlchemy models
+- `slot-monitor-site/auth.py` - Registration and login routes producing JWTs
+- `slot-monitor-site/api_client.py` - Wrapper for third party API calls
+- `slot-monitor-site/routes/game.py` - Blueprint with balance/bet/win endpoints
+- `slot-monitor-site/routes/admin.py` - Admin endpoints protected by JWT
+- `slot-monitor-site/routes/user.py` - Recharge and transaction history APIs
+- `slot-monitor-site/templates/index.html` - Web page showing jackpot logs
+- `slot-monitor-site/static/style.css` - Shared styling
+- `slot-monitor-site/static/login.css` - Login page styling
+- `slot-monitor-site/slot_jackpot_log.txt` - Example log file
+
+## Running
+
+Install dependencies and start the server:
+
+```bash
+pip install flask flask_sqlalchemy pyjwt requests werkzeug
+python slot-monitor-site/app.py
+```
+
+Then open `http://localhost:5000` in a browser to view the logs.
+
+Visit `http://localhost:5000/login` to sign in. A valid JWT token will be stored
+in the browser and used to access the admin dashboard at
+`http://localhost:5000/admin`. The dashboard includes basic charts powered by
+Chart.js and a paginated user table.
+The interface supports basic English/Chinese translations and can be branded via
+environment variables `BRAND_NAME` and `DEFAULT_LANGUAGE` defined in
+`config.py`.
+
+Use `/auth/register` and `/auth/login` to obtain a JWT. Include the token in an
+`Authorization: Bearer <token>` header when calling `/api/admin/*` endpoints.
+You can simulate deposits via `POST /api/user/recharge` and view history with
+`GET /api/user/transactions?user_id=<id>`.

--- a/slot-monitor-site/api_client.py
+++ b/slot-monitor-site/api_client.py
@@ -1,0 +1,23 @@
+import requests
+from flask import current_app
+
+BASE_URL = 'https://example.com/api'
+
+
+def send_request(endpoint, payload):
+    headers = {'Authorization': f"Bearer {current_app.config['API_TOKEN']}"}
+    resp = requests.post(f"{BASE_URL}/{endpoint}", json=payload, headers=headers, timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_balance(user_id):
+    return send_request('balance', {'user_id': user_id})
+
+
+def place_bet(user_id, amount):
+    return send_request('bet', {'user_id': user_id, 'amount': amount})
+
+
+def send_win(user_id, amount):
+    return send_request('win', {'user_id': user_id, 'amount': amount})

--- a/slot-monitor-site/app.py
+++ b/slot-monitor-site/app.py
@@ -1,0 +1,85 @@
+from flask import Flask, jsonify, render_template
+import os
+
+from config import Config
+from models import db, Transaction
+from auth import auth_bp
+from routes.game import game_bp
+from routes.admin import admin_bp
+from routes.user import user_bp
+
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{Config.DATABASE_URI}"
+app.config['SECRET_KEY'] = Config.SECRET_KEY
+app.config['API_TOKEN'] = Config.API_TOKEN
+app.config['BRAND_NAME'] = Config.BRAND_NAME
+app.config['DEFAULT_LANGUAGE'] = Config.DEFAULT_LANGUAGE
+
+db.init_app(app)
+
+
+@app.context_processor
+def inject_config():
+    return {
+        'brand': app.config.get('BRAND_NAME'),
+        'default_lang': app.config.get('DEFAULT_LANGUAGE'),
+    }
+
+
+@app.before_first_request
+def init_db():
+    db.create_all()
+
+
+app.register_blueprint(auth_bp, url_prefix='/auth')
+app.register_blueprint(game_bp, url_prefix='/api')
+app.register_blueprint(admin_bp, url_prefix='/api/admin')
+app.register_blueprint(user_bp, url_prefix='/api/user')
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/login')
+def login_page():
+    """Render dedicated login page."""
+    return render_template('login.html')
+
+
+@app.route('/admin')
+def admin_page():
+    """Render simple admin dashboard page."""
+    return render_template('admin.html')
+
+
+@app.route('/api/logs')
+def api_logs():
+    log_file = Config.LOG_FILE
+    if not os.path.exists(log_file):
+        return jsonify([])
+    with open(log_file, 'r') as f:
+        lines = [line.strip() for line in f if line.strip()]
+    return jsonify(lines)
+
+
+@app.route('/api/transactions')
+def api_transactions():
+    transactions = Transaction.query.order_by(Transaction.timestamp.desc()).limit(100).all()
+    rows = [
+        {
+            'id': t.id,
+            'user_id': t.user_id,
+            'amount': t.amount,
+            'type': t.type,
+            'timestamp': t.timestamp.isoformat()
+        }
+        for t in transactions
+    ]
+    return jsonify(rows)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/slot-monitor-site/auth.py
+++ b/slot-monitor-site/auth.py
@@ -1,0 +1,63 @@
+from flask import Blueprint, request, jsonify, current_app
+from werkzeug.security import generate_password_hash, check_password_hash
+from datetime import datetime, timedelta
+import jwt
+from functools import wraps
+
+from models import db, User
+
+
+auth_bp = Blueprint('auth', __name__)
+
+
+def token_required(f):
+    """Simple JWT token check for protected endpoints."""
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        auth_header = request.headers.get('Authorization', '')
+        if not auth_header.startswith('Bearer '):
+            return jsonify({'error': 'missing token'}), 401
+        token = auth_header.split(' ', 1)[1]
+        try:
+            payload = jwt.decode(
+                token,
+                current_app.config['SECRET_KEY'],
+                algorithms=['HS256'],
+            )
+            request.user_id = payload['sub']
+        except Exception:
+            return jsonify({'error': 'invalid token'}), 401
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    data = request.get_json() or {}
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({'error': 'missing credentials'}), 400
+    if User.query.filter_by(username=username).first():
+        return jsonify({'error': 'user exists'}), 400
+    user = User(username=username, password=generate_password_hash(password))
+    db.session.add(user)
+    db.session.commit()
+    return jsonify({'status': 'registered'})
+
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.get_json() or {}
+    username = data.get('username')
+    password = data.get('password')
+    user = User.query.filter_by(username=username).first()
+    if not user or not check_password_hash(user.password, password):
+        return jsonify({'error': 'invalid credentials'}), 401
+    payload = {
+        'sub': user.id,
+        'exp': datetime.utcnow() + timedelta(hours=2)
+    }
+    token = jwt.encode(payload, current_app.config['SECRET_KEY'], algorithm='HS256')
+    return jsonify({'token': token})

--- a/slot-monitor-site/config.py
+++ b/slot-monitor-site/config.py
@@ -1,0 +1,10 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "change-me")
+    API_TOKEN = os.environ.get("API_TOKEN", "your-api-token")
+    DATABASE_URI = os.path.join(os.path.dirname(__file__), "db.sqlite")
+    LOG_FILE = os.path.join(os.path.dirname(__file__), "slot_jackpot_log.txt")
+    REBATE_PERCENTAGE = float(os.environ.get("REBATE_PERCENTAGE", 0.01))
+    BRAND_NAME = os.environ.get("BRAND_NAME", "PALACE CASINO")
+    DEFAULT_LANGUAGE = os.environ.get("DEFAULT_LANGUAGE", "en")

--- a/slot-monitor-site/models.py
+++ b/slot-monitor-site/models.py
@@ -1,0 +1,33 @@
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password = db.Column(db.String(120), nullable=False)
+    created_at = db.Column(db.DateTime, default=db.func.now())
+    balance = db.Column(db.Float, default=0.0)
+    parent_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    parent = db.relationship('User', remote_side=[id], backref='children')
+
+
+class Transaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    amount = db.Column(db.Float)
+    type = db.Column(db.String(20))
+    timestamp = db.Column(db.DateTime, default=db.func.now())
+    user = db.relationship('User', backref=db.backref('transactions', lazy=True))
+
+
+class BalanceLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    type = db.Column(db.String(20))
+    before = db.Column(db.Float)
+    after = db.Column(db.Float)
+    timestamp = db.Column(db.DateTime, default=db.func.now())
+    user = db.relationship('User', backref=db.backref('balance_logs', lazy=True))

--- a/slot-monitor-site/routes/admin.py
+++ b/slot-monitor-site/routes/admin.py
@@ -1,0 +1,81 @@
+from flask import Blueprint, jsonify
+
+from models import db, User, Transaction
+from auth import token_required
+
+admin_bp = Blueprint('admin', __name__)
+
+
+@admin_bp.route('/transactions')
+@token_required
+def transactions():
+    txs = Transaction.query.order_by(Transaction.timestamp.desc()).limit(100).all()
+    rows = [
+        {
+            'id': t.id,
+            'user_id': t.user_id,
+            'amount': t.amount,
+            'type': t.type,
+            'timestamp': t.timestamp.isoformat(),
+        }
+        for t in txs
+    ]
+    return jsonify(rows)
+
+
+@admin_bp.route('/users')
+@token_required
+def users():
+    users = User.query.all()
+    rows = []
+    for u in users:
+        balance = sum(t.amount if t.type == 'win' else -t.amount for t in u.transactions)
+        txs = [
+            {
+                'id': t.id,
+                'amount': t.amount,
+                'type': t.type,
+                'timestamp': t.timestamp.isoformat(),
+            }
+            for t in u.transactions
+        ]
+        rows.append({'id': u.id, 'username': u.username, 'balance': balance, 'transactions': txs})
+    return jsonify(rows)
+
+
+@admin_bp.route('/stats')
+@token_required
+def stats():
+    """Return daily profit and user count for the last 7 days."""
+    from datetime import datetime, timedelta
+    today = datetime.utcnow().date()
+    data = []
+    for i in range(7):
+        day = today - timedelta(days=i)
+        next_day = day + timedelta(days=1)
+        bets = (
+            Transaction.query.filter(
+                Transaction.type == 'bet',
+                Transaction.timestamp >= day,
+                Transaction.timestamp < next_day,
+            )
+            .with_entities(db.func.sum(Transaction.amount))
+            .scalar()
+            or 0
+        )
+        wins = (
+            Transaction.query.filter(
+                Transaction.type == 'win',
+                Transaction.timestamp >= day,
+                Transaction.timestamp < next_day,
+            )
+            .with_entities(db.func.sum(Transaction.amount))
+            .scalar()
+            or 0
+        )
+        profit = wins - bets
+        user_count = (
+            User.query.filter(User.created_at < next_day).count()
+        )
+        data.append({'day': day.isoformat(), 'profit': profit, 'users': user_count})
+    return jsonify(list(reversed(data)))

--- a/slot-monitor-site/routes/game.py
+++ b/slot-monitor-site/routes/game.py
@@ -1,0 +1,68 @@
+from flask import Blueprint, request, jsonify, current_app
+
+from models import db, User, Transaction, BalanceLog
+from api_client import get_balance as api_get_balance, place_bet as api_place_bet, send_win as api_send_win
+
+
+game_bp = Blueprint('game', __name__)
+
+
+def _update_balance(user, change, log_type):
+    before = user.balance
+    user.balance = before + change
+    log = BalanceLog(user_id=user.id, type=log_type, before=before, after=user.balance)
+    db.session.add(log)
+
+
+@game_bp.route('/balance')
+def balance():
+    user_id = request.args.get('user_id')
+    if not user_id:
+        return jsonify({'error': 'missing user_id'}), 400
+    api_resp = api_get_balance(user_id)
+    user = User.query.get(user_id)
+    local = user.balance if user else None
+    return jsonify({'api': api_resp, 'local': local})
+
+
+@game_bp.route('/bet', methods=['POST'])
+def bet():
+    data = request.get_json() or {}
+    user_id = data.get('user_id')
+    amount = data.get('amount')
+    if not user_id or amount is None:
+        return jsonify({'error': 'missing fields'}), 400
+    user = User.query.get(user_id)
+    if not user:
+        return jsonify({'error': 'user not found'}), 404
+    api_resp = api_place_bet(user_id, amount)
+    tx = Transaction(user_id=user_id, amount=amount, type='bet')
+    db.session.add(tx)
+    _update_balance(user, -amount, 'bet')
+    # rebate for parent
+    if user.parent:
+        percent = current_app.config.get('REBATE_PERCENTAGE', 0)
+        rebate = amount * percent
+        parent_tx = Transaction(user_id=user.parent.id, amount=rebate, type='rebate')
+        db.session.add(parent_tx)
+        _update_balance(user.parent, rebate, 'rebate')
+    db.session.commit()
+    return jsonify(api_resp)
+
+
+@game_bp.route('/win', methods=['POST'])
+def win():
+    data = request.get_json() or {}
+    user_id = data.get('user_id')
+    amount = data.get('amount')
+    if not user_id or amount is None:
+        return jsonify({'error': 'missing fields'}), 400
+    user = User.query.get(user_id)
+    if not user:
+        return jsonify({'error': 'user not found'}), 404
+    api_resp = api_send_win(user_id, amount)
+    tx = Transaction(user_id=user_id, amount=amount, type='win')
+    db.session.add(tx)
+    _update_balance(user, amount, 'win')
+    db.session.commit()
+    return jsonify(api_resp)

--- a/slot-monitor-site/routes/user.py
+++ b/slot-monitor-site/routes/user.py
@@ -1,0 +1,49 @@
+from flask import Blueprint, request, jsonify
+
+from models import db, User, Transaction, BalanceLog
+
+user_bp = Blueprint('user', __name__)
+
+
+def _update_balance(user, change, log_type):
+    before = user.balance
+    user.balance = before + change
+    log = BalanceLog(user_id=user.id, type=log_type, before=before, after=user.balance)
+    db.session.add(log)
+
+
+@user_bp.route('/recharge', methods=['POST'])
+def recharge():
+    data = request.get_json() or {}
+    user_id = data.get('user_id')
+    amount = data.get('amount')
+    if not user_id or amount is None:
+        return jsonify({'error': 'missing fields'}), 400
+    user = User.query.get(user_id)
+    if not user:
+        return jsonify({'error': 'user not found'}), 404
+    tx = Transaction(user_id=user_id, amount=amount, type='recharge')
+    db.session.add(tx)
+    _update_balance(user, amount, 'recharge')
+    db.session.commit()
+    return jsonify({'status': 'ok', 'balance': user.balance})
+
+
+@user_bp.route('/transactions')
+def user_transactions():
+    user_id = request.args.get('user_id')
+    if not user_id:
+        return jsonify({'error': 'missing user_id'}), 400
+    user = User.query.get(user_id)
+    if not user:
+        return jsonify({'error': 'user not found'}), 404
+    txs = [
+        {
+            'id': t.id,
+            'amount': t.amount,
+            'type': t.type,
+            'timestamp': t.timestamp.isoformat(),
+        }
+        for t in user.transactions
+    ]
+    return jsonify({'balance': user.balance, 'transactions': txs})

--- a/slot-monitor-site/slot_jackpot_log.txt
+++ b/slot-monitor-site/slot_jackpot_log.txt
@@ -1,0 +1,1 @@
+Sample jackpot at 2023-01-01

--- a/slot-monitor-site/static/login.css
+++ b/slot-monitor-site/static/login.css
@@ -1,0 +1,16 @@
+.login-container {
+    width: 320px;
+    margin: 80px auto;
+    padding: 20px;
+    border: 1px solid #ccc;
+    background-color: #fff;
+}
+.login-container input {
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 10px;
+}
+.login-container button {
+    width: 100%;
+    padding: 8px;
+}

--- a/slot-monitor-site/static/style.css
+++ b/slot-monitor-site/static/style.css
@@ -1,0 +1,21 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+pre {
+    background-color: #f4f4f4;
+    padding: 10px;
+    border: 1px solid #ccc;
+    overflow: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 10px;
+}
+th, td {
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    text-align: left;
+}

--- a/slot-monitor-site/templates/admin.html
+++ b/slot-monitor-site/templates/admin.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ brand }} Admin</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const translations = {
+            en: {users:'Users', profit:'Profit', next:'Next', prev:'Prev'},
+            zh: {users:'\u7528\u6237', profit:'\u76c8\u5229', next:'\u4e0b\u4e00\u9875', prev:'\u4e0a\u4e00\u9875'}
+        };
+        let currentLang = localStorage.getItem('lang') || '{{ default_lang }}';
+        function t(key){return (translations[currentLang]||translations.en)[key]||key;}
+        function changeLang(lang){currentLang=lang;localStorage.setItem('lang',lang);applyLang();}
+        function applyLang(){
+            document.getElementById('users-title').textContent=t('users');
+            document.getElementById('prev').textContent=t('prev');
+            document.getElementById('next').textContent=t('next');
+        }
+        function requireToken() {
+            const token = localStorage.getItem('token');
+            if (!token) {
+                window.location.href = '/login';
+            }
+            return token;
+        }
+
+        async function apiRequest(path) {
+            const token = requireToken();
+            const resp = await fetch(path, {headers: {Authorization: 'Bearer ' + token}});
+            return resp.json();
+        }
+
+        function renderTable(users) {
+            const tbody = document.getElementById('user-body');
+            tbody.innerHTML = '';
+            const perPage = 10;
+            let page = 0;
+            function draw() {
+                tbody.innerHTML = '';
+                const start = page * perPage;
+                users.slice(start, start + perPage).forEach(u => {
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `<td>${u.id}</td><td>${u.username}</td><td>${u.balance.toFixed(2)}</td>`;
+                    tbody.appendChild(tr);
+                });
+                document.getElementById('page-num').textContent = page + 1;
+            }
+            document.getElementById('prev').onclick = () => { if (page>0){page--;draw();}};
+            document.getElementById('next').onclick = () => { if ((page+1)*perPage < users.length){page++;draw();}};
+            draw();
+        }
+
+        function drawChart(stats) {
+            const ctx = document.getElementById('profit-chart');
+            const labels = stats.map(s => s.day);
+            const profitData = stats.map(s => s.profit);
+            const userData = stats.map(s => s.users);
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [
+                        {label: t('profit'), data: profitData, borderColor: 'blue', fill:false},
+                        {label: t('users'), data: userData, borderColor: 'green', fill:false}
+                    ]
+                }
+            });
+        }
+
+        async function loadData() {
+            const [users, stats] = await Promise.all([
+                apiRequest('/api/admin/users'),
+                apiRequest('/api/admin/stats')
+            ]);
+            renderTable(users);
+            drawChart(stats);
+            applyLang();
+        }
+        window.addEventListener('DOMContentLoaded', loadData);
+    </script>
+</head>
+<body>
+    <h1>{{ brand }} Admin</h1>
+    <div>
+        <label for="lang">Language:</label>
+        <select id="lang" onchange="changeLang(this.value)">
+            <option value="en">English</option>
+            <option value="zh">\u4e2d\u6587</option>
+        </select>
+    </div>
+    <section>
+        <canvas id="profit-chart" width="400" height="200"></canvas>
+    </section>
+    <section>
+        <h2 id="users-title">Users</h2>
+        <table>
+            <thead><tr><th>ID</th><th>Name</th><th>Balance</th></tr></thead>
+            <tbody id="user-body"></tbody>
+        </table>
+        <button id="prev">Prev</button>
+        <span id="page-num">1</span>
+        <button id="next">Next</button>
+    </section>
+</body>
+</html>

--- a/slot-monitor-site/templates/index.html
+++ b/slot-monitor-site/templates/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ brand }} Slot Monitor</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <script>
+        async function loadLogs() {
+            const resp = await fetch('/api/logs');
+            const data = await resp.json();
+            const container = document.getElementById('logs');
+            container.textContent = data.join('\n');
+        }
+        window.addEventListener('DOMContentLoaded', loadLogs);
+    </script>
+</head>
+<body>
+    <h1>{{ brand }} Jackpot Logs</h1>
+    <p><a href="/login">Login</a> | <a href="/admin">Admin</a></p>
+    <pre id="logs">Loading...</pre>
+</body>
+</html>

--- a/slot-monitor-site/templates/login.html
+++ b/slot-monitor-site/templates/login.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ brand }} Login</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="/static/login.css">
+    <script>
+        async function login() {
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            const resp = await fetch('/auth/login', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({username, password})
+            });
+            const data = await resp.json();
+            if (data.token) {
+                localStorage.setItem('token', data.token);
+                window.location.href = '/admin';
+            } else {
+                document.getElementById('status').textContent = data.error || 'Login failed';
+            }
+        }
+    </script>
+</head>
+<body class="login-page">
+    <div class="login-container">
+        <h1>{{ brand }} Admin</h1>
+        <input id="username" placeholder="username">
+        <input id="password" type="password" placeholder="password">
+        <button onclick="login()">Login</button>
+        <div id="status"></div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restructure Flask app to use SQLAlchemy models
- add JWT-based registration and login routes
- implement third-party API wrapper
- move bet/win/balance to a blueprint
- add admin endpoints protected by JWT
- document new modules and setup
- add user recharge and transaction history endpoints
- track balances with `BalanceLog` model and apply rebates
- add admin dashboard page
- brandable login page and admin dashboard
- show charts and paginated user table
- multi-language support via config

## Testing
- `python -m py_compile slot-monitor-site/app.py slot-monitor-site/models.py slot-monitor-site/auth.py slot-monitor-site/api_client.py slot-monitor-site/routes/game.py slot-monitor-site/routes/admin.py slot-monitor-site/routes/user.py`

------
https://chatgpt.com/codex/tasks/task_e_6862398b57088326a5d0d4c34ef5edf0